### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-PyQt5
+PyQt5 >= 5.14.0
 spotipy
 schedule


### PR DESCRIPTION
Loosening the version range: We can try to loosen the version requirements for pyqt5-tools or its dependencies. This might allow pip to find a compatible combination. We can do this by specifying a broader version range in our file or by using a wildcard character like >= 5.14.0 instead of an exact version number.

OR

Removing package versions to allow pip attempt to solve the dependency conflict.
